### PR TITLE
fix(config): fix config error to load config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,4 @@ CMD ["--help"]
 LABEL maintainer="ogonnannamani11@gmail.com" \
       description="Sentry Terraform Discovery Tool" \
       version="1.0.0" \
-      org.opencontainers.image.source="https://github.com/litmus-paper-blue/sentry-terraform-discovery"
+      org.opencontainers.image.source="https://github.com/litmus-paper-blue/sentry-terraform-migration-toolkit"

--- a/src/sentry_discovery/config.py
+++ b/src/sentry_discovery/config.py
@@ -141,6 +141,7 @@ class Config:
             sentry_data = data['sentry']
             config.sentry.base_url = sentry_data.get('base_url', config.sentry.base_url)
             config.sentry.organization = sentry_data.get('organization', config.sentry.organization)
+            config.sentry.token = sentry_data.get('token', config.sentry.token)
             config.sentry.timeout = sentry_data.get('timeout', config.sentry.timeout)
             config.sentry.retry_attempts = sentry_data.get('retry_attempts', config.sentry.retry_attempts)
         


### PR DESCRIPTION
This PR fixes the error where the config file is ignored. If you run `sentry-discovery --verbose `the config file 
`".sentry-discovery.yaml"` will be considered first.

